### PR TITLE
Connect and Disconnect handling across Origins

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -224,7 +224,7 @@ const App = () => {
     const serverUrl = params.get("serverUrl");
     if (serverUrl) {
       setSseUrl(serverUrl);
-      setTransportType("sse");
+      // setTransportType("sse");
       // Remove serverUrl from URL without reloading the page
       const newUrl = new URL(window.location.href);
       newUrl.searchParams.delete("serverUrl");

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -8,6 +8,12 @@ export const SESSION_KEYS = {
   CLIENT_INFORMATION: "mcp_client_information",
 } as const;
 
+export const clearSessionKeys = () => {
+  Object.values(SESSION_KEYS).forEach((key) => {
+    sessionStorage.removeItem(key);
+  });
+};
+
 export type ConnectionStatus =
   | "disconnected"
   | "connected"

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -8,12 +8,6 @@ export const SESSION_KEYS = {
   CLIENT_INFORMATION: "mcp_client_information",
 } as const;
 
-export const clearSessionKeys = () => {
-  Object.values(SESSION_KEYS).forEach((key) => {
-    sessionStorage.removeItem(key);
-  });
-};
-
 export type ConnectionStatus =
   | "disconnected"
   | "connected"

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -45,7 +45,7 @@ import {
 } from "@/utils/configUtils";
 import { getMCPServerRequestTimeout } from "@/utils/configUtils";
 import { InspectorConfig } from "../configurationTypes";
-import { clearSessionKeys } from "../constants";
+
 
 interface UseConnectionOptions {
   transportType: "stdio" | "sse" | "streamableHttp"; // Added streamableHttp
@@ -251,6 +251,11 @@ export function useConnection({
     }
   };
 
+  const clearSessionKeys = () => {
+      Object.values(SESSION_KEYS).forEach((key) => {
+          sessionStorage.removeItem(key);
+      });
+  };
 
   const handleAuthError = async (error: unknown) => {
     // This function might need adjustment if StreamableHttpTransport handles auth differently

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -3,7 +3,10 @@ import {
   SSEClientTransport,
   SseError,
 } from "@modelcontextprotocol/sdk/client/sse.js";
-import { StreamableHttpClientTransport as StreamableHttpTransport } from "../transports/StreamableHttpTransport"; // Corrected path
+import { 
+    StreamableHttpClientTransport as StreamableHttpTransport,
+    StreamableHttpError 
+} from "../transports/StreamableHttpTransport"; // Corrected path
 
 import {
   ClientNotification,
@@ -42,6 +45,7 @@ import {
 } from "@/utils/configUtils";
 import { getMCPServerRequestTimeout } from "@/utils/configUtils";
 import { InspectorConfig } from "../configurationTypes";
+import { clearSessionKeys } from "../constants";
 
 interface UseConnectionOptions {
   transportType: "stdio" | "sse" | "streamableHttp"; // Added streamableHttp
@@ -247,9 +251,13 @@ export function useConnection({
     }
   };
 
+
   const handleAuthError = async (error: unknown) => {
     // This function might need adjustment if StreamableHttpTransport handles auth differently
-    if (error instanceof SseError && error.code === 401) {
+    if ((error instanceof SseError || error instanceof StreamableHttpError) && error.code === 401) {
+      if (SESSION_KEYS.SERVER_URL != sseUrl) {
+          clearSessionKeys();
+      }
       sessionStorage.setItem(SESSION_KEYS.SERVER_URL, sseUrl);
 
       const result = await auth(authProvider, { serverUrl: sseUrl });
@@ -364,13 +372,13 @@ export function useConnection({
         error,
       );
       // Handle auth errors specifically for SSE via proxy
-      if (transportType !== 'streamableHttp') {
+      if (true || (transportType !== 'streamableHttp')) {
         const shouldRetry = await handleAuthError(error);
         if (shouldRetry) {
           return connect(undefined, retryCount + 1);
         }
 
-        if (error instanceof SseError && error.code === 401) {
+        if ((error instanceof SseError || error instanceof StreamableHttpError) && error.code === 401) {
           // Don't set error state if we're about to redirect for auth
           return;
         }


### PR DESCRIPTION
Removes the need to manually remove credentials from browser storage when switching SSE (Server Sent Events) connections between Origins. This makes OAuth authentication experience smoother.